### PR TITLE
Enable different object types to be encrypted

### DIFF
--- a/lib/attr_encrypted.rb
+++ b/lib/attr_encrypted.rb
@@ -343,7 +343,7 @@ module AttrEncrypted
     #  @user.encrypt(:email, 'test@example.com')
     def encrypt(attribute, value)
       encrypted_attributes[attribute.to_sym][:operation] = :encrypting
-      encrypted_attributes[attribute.to_sym][:value_present] = (value && !value.empty?)
+      encrypted_attributes[attribute.to_sym][:value_present] = (value && not_empty?(value))
       self.class.encrypt(attribute, value, evaluated_attr_encrypted_options_for(attribute))
     end
 
@@ -355,6 +355,10 @@ module AttrEncrypted
     end
 
     protected
+
+      def not_empty?(value)
+        !value.nil? && !(value.is_a?(String) && value.empty?)
+      end
 
       # Returns attr_encrypted options evaluated in the current object's scope for the attribute specified
       def evaluated_attr_encrypted_options_for(attribute)


### PR DESCRIPTION
Currently booleans and Ruby objects break when trying to be encrypted because the string method #empty? is called on them. This commit changes that check to use the #not_empty? method already written specifically to check objects that are not strings.